### PR TITLE
docs(core): update readme with local setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # e2e-a11y-testing
 Recommended end-to-end accessibility testing for web projects
+
+## Requirements
+
+* [nodejs: >= 16](https://nodejs.org/en)
+* [pnpm](https://pnpm.io)
+
+## Installation
+
+To install, you'll need to clone the repository locally and change to the root directory of it.  Then run the following commands:
+
+```bash
+pnpm install
+npx playwright install
+```
+
+## Running tests
+
+To run all scripts: `npx playwright test`
+
+To run a specific test file: `npx playwright test <relative_path_to_file>`

--- a/README.md
+++ b/README.md
@@ -1,21 +1,44 @@
 # e2e-a11y-testing
+
 Recommended end-to-end accessibility testing for web projects
 
 ## Requirements
 
 * [nodejs: >= 16](https://nodejs.org/en)
-* [pnpm](https://pnpm.io)
+* A package manager:
+  * [npm](https://www.npmjs.com)
+  * [pnpm](https://pnpm.io)
+  * [yarn](https://yarnpkg.com)
 
 ## Installation
 
-To install, you'll need to clone the repository locally and change to the root directory of it.  Then run the following commands:
+To install, you'll need to clone the repository locally and change to the root
+directory of it.  Then run the following commands:
+
+### For `npm`
+
+```bash
+npm install
+npx playwright install
+```
+
+### For `pnpm`
 
 ```bash
 pnpm install
 npx playwright install
 ```
 
+### For `yarn`
+
+```bash
+yarn install
+yarn playwright install
+```
+
 ## Running tests
+
+### pnpm/npm
 
 To run all tests:
 
@@ -27,4 +50,18 @@ To run a specific test file:
 
 ```bash
 npx playwright test <relative_path_to_file>
+```
+
+### yarn
+
+To run all tests:
+
+```bash
+yarn playwright test
+```
+
+To run a specific test file:
+
+```bash
+yarn playwright test <relative_path_to_file>
 ```

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Recommended end-to-end accessibility testing for web projects
 
 * [nodejs: >= 16](https://nodejs.org/en)
 * [npm](https://www.npmjs.com)
+* [xmllint](https://gitlab.gnome.org/GNOME/libxml2/-/wikis/home)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npx playwright install
 
 ## Running tests
 
-To run all scripts:
+To run all tests:
 
 ```bash
 npx playwright test

--- a/README.md
+++ b/README.md
@@ -21,14 +21,32 @@ npx playwright install
 
 ## Running tests
 
-To run all tests:
+To run axe tests on a remote site containing a sitemap.xml file:
+
+```bash
+npm run a11y <base_url>
+```
+
+`base_url`: The url of the site containing the sitemap.xml file (i.e.
+https://www.example.com)
+
+To retrieve the sitemap links into a file called `sitemap.links`:
+```bash
+npm run sitemap <base_url>
+```
+
+`base_url`: The url of the site containing the sitemap.xml file (i.e.
+https://www.example.com)
+
+To manually run all tests:
 
 ```bash
 npx playwright test
 ```
 
-To run a specific test file:
+To manually run a specific test file:
 
 ```bash
 npx playwright test <relative_path_to_file>
 ```
+

--- a/README.md
+++ b/README.md
@@ -5,10 +5,7 @@ Recommended end-to-end accessibility testing for web projects
 ## Requirements
 
 * [nodejs: >= 16](https://nodejs.org/en)
-* A package manager:
-  * [npm](https://www.npmjs.com)
-  * [pnpm](https://pnpm.io)
-  * [yarn](https://yarnpkg.com)
+* [npm](https://www.npmjs.com)
 
 ## Installation
 
@@ -22,23 +19,7 @@ npm install
 npx playwright install
 ```
 
-### For `pnpm`
-
-```bash
-pnpm install
-npx playwright install
-```
-
-### For `yarn`
-
-```bash
-yarn install
-yarn playwright install
-```
-
 ## Running tests
-
-### pnpm/npm
 
 To run all tests:
 
@@ -50,18 +31,4 @@ To run a specific test file:
 
 ```bash
 npx playwright test <relative_path_to_file>
-```
-
-### yarn
-
-To run all tests:
-
-```bash
-yarn playwright test
-```
-
-To run a specific test file:
-
-```bash
-yarn playwright test <relative_path_to_file>
 ```

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ npx playwright install
 
 ## Running tests
 
-To run all scripts: `npx playwright test`
+To run all scripts:
 
-To run a specific test file: `npx playwright test <relative_path_to_file>`
+```bash
+npx playwright test
+```
+
+To run a specific test file:
+
+```bash
+npx playwright test <relative_path_to_file>
+```


### PR DESCRIPTION
Creates initial documentation for setup in a local Linux/MacOS environment with easily copyable command line instructions.

See readme on the repository's branch page: https://github.com/Yale-A11y/e2e-a11y-testing/tree/6-doc-score-update-readme-with-local-setup-instructions

### Acceptance criteria:
- [ ] Installation steps work when following them
- [ ] Grammar and spelling are acceptable