### PR TITLE
Sitemap-based testing and slightly better output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 
 # Mac directory meta information files
 .DS_Store
+
+# The sitemap links that you can generate
+sitemap.links

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "scripts": {
+    "a11y": "./scripts/sitemap-test",
+    "sitemap": "./scripts/retrieveSitemap",
+    "sitemap-alt": "node ./sitemap.js"
+  },
   "devDependencies": {
     "@playwright/test": "^1.37.1"
   },

--- a/scripts/retrieveSitemap
+++ b/scripts/retrieveSitemap
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+curl "$1/sitemap.xml" 2>/dev/null | xmllint --xpath '//*[local-name()="loc"]/text()' --format - > sitemap.links
+
+if [ ! -f sitemap.links ]; then
+    echo "Could not retrieve sitemap.xml"
+    exit 1
+fi
+
+echo "Retrieved sitemap.links"

--- a/scripts/sitemap-test
+++ b/scripts/sitemap-test
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+./scripts/retrieveSitemap "$1"
+playwright test ./tests/axe-sitemap.spec.ts

--- a/sitemap.js
+++ b/sitemap.js
@@ -1,0 +1,65 @@
+const https = require('https');
+const fs = require('fs');
+
+const site = process.argv[2];
+const sitemapURL = `${site}/sitemap.xml`;
+const outputFile = 'sitemap.links';
+
+function fetchData(url) {
+  return new Promise((resolve, reject) => {
+    const req = https.get(url, (res) => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`Request failed with status code ${res.statusCode}`));
+        return;
+      }
+
+      let data = '';
+
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+
+      res.on('end', () => {
+        resolve(data);
+      });
+    });
+
+    req.on('error', (error) => {
+      reject(error);
+    });
+
+    req.end();
+  });
+}
+
+async function parseSitemap() {
+  try {
+    const sitemapData = await fetchData(sitemapURL);
+    const locs = [];
+
+    // Parse the XML content manually
+    const locStart = '<loc>';
+    const locEnd = '</loc>';
+
+    let startIndex = 0;
+    while (startIndex !== -1) {
+      startIndex = sitemapData.indexOf(locStart, startIndex);
+      if (startIndex !== -1) {
+        const endIndex = sitemapData.indexOf(locEnd, startIndex);
+        if (endIndex !== -1) {
+          const locValue = sitemapData.substring(startIndex + locStart.length, endIndex);
+          locs.push(locValue);
+          startIndex = endIndex + locEnd.length;
+        }
+      }
+    }
+
+    fs.writeFileSync(outputFile, locs.join('\n'));
+    console.log(`Sitemap urls written to ${outputFile}`);
+  } catch (error) {
+    console.error('Error fetching or parsing sitemap:', error.message);
+  }
+}
+
+// Call the function to start the process
+parseSitemap();

--- a/tests/axe-sitemap.spec.ts
+++ b/tests/axe-sitemap.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import type { Result, NodeResult } from "axe-core";
+import fs from "fs";
+
+const links = fs
+  .readFileSync("sitemap.links", "utf-8")
+  .split("\n")
+  .filter((link) => link !== "");
+
+links.forEach((link) => {
+  test(`Accessibility test for ${link}`, async ({ page }) => {
+    await page.goto(link);
+    const results = await new AxeBuilder({ page }).analyze();
+    if (results.violations.length > 0) {
+      console.log(`Violations for ${link}`);
+      outputViolations(results.violations);
+    }
+    expect(results.violations.length).toBe(0);
+  });
+});
+
+const outputViolations = (violations: Result[]) => {
+  violations.forEach((violation) => outputViolation(violation));
+};
+
+const outputViolation = (violation: Result) => {
+  let { id, impact, description, nodes } = violation;
+
+  console.log(`\n`);
+  console.log(`----------------------------------------`);
+  console.log(`Violation: ${id} (${impact})`);
+  console.log(`Description: ${description}`);
+  console.log(`Affected nodes:`);
+  outputNodes(nodes);
+};
+
+const outputNodes = (nodes: NodeResult[]) => {
+  nodes.forEach((node) => outputNode(node));
+};
+
+const outputNode = (node: NodeResult) => {
+    let { html, target } = node;
+
+    console.log(`  ${target}`);
+    console.log(`  ${html}`);
+    console.log(`  ----------------`);
+    console.log(`  ${node.failureSummary}`);
+};
+


### PR DESCRIPTION
Addresses #5 by adding sitemap pulling through bash command line prompt.
It also attempts to start the addressing of #7 by providing a stdout representation of the findings that can be looked at in the outputting HTML, as well as inline in a CLI version.

I found the reasoning for a bash-based solution is due to playwright needing tests scoped in the current file level.  Using a promise or async results in the wrong scope occurring when defining the test.  By using IO to retrieve the list, we perform a blocking action, resulting in the tests occurring at the right scope level.

## Acceptance criteria
- [ ] Can run `pnpm run sitemap https://yalesites.yale.edu` and a sitemap.links file is created
  - [ ] The `sitemap.links` file is a text file containing return-delimited URLs from the sitemap.xml file.
- [ ] Running `npx playwright test ./tests/axe-sitemap.spec.ts` results in a running test of the `sitemap.links` URL contents
- [ ] The output of an errored page has a `stdout` section at the bottom, listing the violations in a slightly more readable format.  (more of a proof of concept than a finished item)
- [ ] Running `pnpm run a11y https://yalesites.yale.edu` results in a sitemap.links file being retrieved and the a11y tests being ran as an all-in-one-run solution.