### PR TITLE
feat(axe): provide better output of findings

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,10 +21,11 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
+  timeout: 60000,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    // baseURL: 'http://127.0.0.1:3000',
+    baseURL: process.env.TEST_URL || 'http://localhost:3000',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',

--- a/scripts/retrieveSitemap
+++ b/scripts/retrieveSitemap
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-curl "$1/sitemap.xml" 2>/dev/null | xmllint --xpath '//*[local-name()="loc"]/text()' --format - > sitemap.links
+curl --insecure "$1/sitemap.xml" 2>/dev/null | xmllint --xpath '//*[local-name()="loc"]/text()' --format - > sitemap.links
 
 if [ ! -f sitemap.links ]; then
     echo "Could not retrieve sitemap.xml"

--- a/support/a11y-page.ts
+++ b/support/a11y-page.ts
@@ -1,0 +1,137 @@
+import { expect as baseExpect, type Page } from "@playwright/test";
+import AxeBuilder from "@axe-core/playwright";
+import type { Result, NodeResult, AxeResults } from "axe-core";
+
+/*
+ * Output axe result violations in a format that is easier to read.
+ *
+ * @param {Result[]} violations - An array of violations
+ * @param {integer} indentation - the number of 2 spaces to use as indention to
+ *                                output
+ *
+ * @returns {string} - A string with the violations formatted for output.
+ *
+ */
+const violationOutput = {
+  outputViolations: (violations: Result[]) => {
+    return violations
+      .map((violation) => violationOutput._outputViolation(violation))
+      .join("\n");
+  },
+
+  _outputViolation: (violation: Result, indentation = 0) => {
+    let { id, impact, description, nodes } = violation;
+    const indentedString = violationOutput.createIndentation(indentation);
+
+    return `
+${indentedString}--------------------------------------------------------------------------------
+${indentedString}Violation: ${id} (${impact})
+${indentedString}Description: ${description}
+${indentedString}Affected nodes:
+${indentedString}${violationOutput._outputNodes(nodes, indentation + 1)}
+    `;
+  },
+
+  _outputNodes: (nodes: NodeResult[], indentation = 0) => {
+    return Array.from(nodes, (node) =>
+      violationOutput._outputNode(node, indentation),
+    ).join("\n");
+  },
+
+  _outputNode: (node: NodeResult, indention = 0) => {
+    let { html, target } = node;
+
+    let indentionString = "  ".repeat(indention);
+
+    return `
+${indentionString}----------------------------------------
+${indentionString}${target}
+${indentionString}${html}
+
+${indentionString}${node.failureSummary}
+    `;
+  },
+  createIndentation(indention: number) {
+    return "  ".repeat(indention);
+  },
+};
+
+/*
+ * Extend the expect object with a new matcher to check for accessibility.
+ *
+ * @param {Page} page - The page to test
+ * @param {string[]} tags - An array of axe tags to test against
+ *
+ * @returns {object} - An object with the pass/fail results of the test.
+ */
+export const expect = baseExpect.extend({
+  async toPassAxe(
+    page: Page,
+    options: {
+      tags: Array<string>;
+      options?: { timeout?: number };
+      outputBuffer?: typeof violationOutput;
+    },
+  ) {
+    if (!options.outputBuffer) {
+      options.outputBuffer = violationOutput;
+    }
+
+    const { tags, options: axePageOptions, outputBuffer } = options;
+    const axePage = new AxePage(page, { tags, ...axePageOptions });
+    let pass: boolean;
+    let matcherResult: any;
+    const expected = 0;
+
+    const results = await axePage.evaluate();
+
+    try {
+      baseExpect(results.violations.length).toBe(0);
+      pass = true;
+    } catch (e: any) {
+      pass = false;
+      matcherResult = e.matcherResult;
+    }
+
+    const message = pass
+      ? () => "True"
+      : () => {
+          return outputBuffer.outputViolations(results.violations);
+        };
+
+    return {
+      message,
+      pass,
+      name: "toBeAccessible",
+      expected,
+      actual: matcherResult?.actual,
+    };
+  },
+});
+
+/*
+ * A wrapper around axe-core/playwright to make it easier to use.
+ */
+export class AxePage {
+  private readonly axeBuilder: AxeBuilder;
+  public results: AxeResults;
+
+  constructor(
+    public readonly page: Page,
+    public readonly options = { tags: [] as string[] },
+  ) {
+    let axeBuilder = new AxeBuilder({ page });
+
+    if (options.tags && options.tags.length > 0) {
+      axeBuilder.withTags(options.tags);
+    }
+
+    this.axeBuilder = axeBuilder;
+  }
+
+  async evaluate(): Promise<AxeResults> {
+    this.results = await this.axeBuilder.analyze();
+    return this.results;
+  }
+}
+

--- a/support/sitemap-links.ts
+++ b/support/sitemap-links.ts
@@ -1,0 +1,29 @@
+import * as fs from "fs";
+
+/*
+ * Given a filename, encoding, and a filter callback, return an array of links
+ * from the sitemap xml
+ *
+ * @param filename - The filename of the sitemap
+ * @param encoding - The encoding of the sitemap (defaults to UTF-8)
+ * @param filterCallback - A callback to filter the links (defaults to exclude
+ *                         empty lines)
+ *
+ * @returns An array of links from the sitemap
+ */
+export default function getSitemapLinks(
+  filename: string,
+  encoding: BufferEncoding = "utf-8",
+  filterCallback: (link: string) => boolean = (link: string) => link !== "",
+) {
+  try {
+    return fs
+      .readFileSync(filename, encoding)
+      .split("\n")
+      .filter(filterCallback);
+  } catch (err) {
+    console.log(err);
+    return null;
+  }
+}
+

--- a/tests/axe-sitemap.spec.ts
+++ b/tests/axe-sitemap.spec.ts
@@ -1,7 +1,6 @@
-import { test, expect } from "@playwright/test";
-import AxeBuilder from "@axe-core/playwright";
-import type { Result, NodeResult } from "axe-core";
-import fs from "fs";
+import { test } from "@playwright/test";
+import { expect } from "@support/a11y-page";
+import getSitemapLinks from "@support/sitemap-links";
 
 const axe_tags = [
   "wcag2a",
@@ -16,47 +15,9 @@ const axe_tags = [
   // "experimental",    // Cutting-edge rules
 ];
 
-const links = fs
-  .readFileSync("sitemap.links", "utf-8")
-  .split("\n")
-  .filter((link) => link !== "");
-
-links.forEach((link) => {
+getSitemapLinks("sitemap.links").forEach((link: string) => {
   test(`Accessibility test for ${link}`, async ({ page }) => {
     await page.goto(link);
-    const results = await new AxeBuilder({ page }).withTags(axe_tags).analyze();
-    if (results.violations.length > 0) {
-      console.log(`Violations for ${link}`);
-      outputViolations(results.violations);
-    }
-    expect(results.violations.length).toBe(0);
+    await expect(page).toPassAxe({ tags: axe_tags });
   });
 });
-
-const outputViolations = (violations: Result[]) => {
-  violations.forEach((violation) => outputViolation(violation));
-};
-
-const outputViolation = (violation: Result) => {
-  let { id, impact, description, nodes } = violation;
-
-  console.log(`\n`);
-  console.log(`----------------------------------------`);
-  console.log(`Violation: ${id} (${impact})`);
-  console.log(`Description: ${description}`);
-  console.log(`Affected nodes:`);
-  outputNodes(nodes);
-};
-
-const outputNodes = (nodes: NodeResult[]) => {
-  nodes.forEach((node) => outputNode(node));
-};
-
-const outputNode = (node: NodeResult) => {
-  let { html, target } = node;
-
-  console.log(`  ----------------`);
-  console.log(`  ${target}`);
-  console.log(`  ${html}`);
-  console.log(`  ${node.failureSummary}`);
-};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".", // This must be specified if "paths" is.
+    "paths": {
+      "@support/*": ["support/*"] // This mapping is relative to "baseUrl".
+    }
+  }
+}
+


### PR DESCRIPTION
Before, we would output issues found in the axe-sitemap to the stdout, resulting in an attachment of sorts toward the bottom of a test for that page.  This caused the developer to have to scroll down to expand the stdout to see the error.  Now this is done as part of the reporter findings, making it much easier to see what needs to be done without the need for stdout.

This also introduces the optional use of an environment variable to serve as the BASE_URL for any test you would write.  For instance, you could set:

`TEST_URL=http://localhost:3000 npx playwright test <file>` and it would use the TEST_URL provided as the base url.  This results in not needing to specify the whole URL in the page visits of your tests.  Instead, you can use the relative path and it'll prepend the base URL.

This also allows retrieveSitemap to allow insecure sites in the event you have a self signed certificate locally, but would still like to test it.