### PR TITLE
fix(sitemap-testing): explicitly set sitemap.xml in call

### DIFF
--- a/scripts/a11y-sitemap-test
+++ b/scripts/a11y-sitemap-test
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 
-./scripts/retrieveSitemap "$1"
+if [[ $1 != *.xml ]]; then
+    echo "$1" > ./sitemap.links
+else
+    ./scripts/retrieveSitemap "$1"
+fi
+
 playwright test ./tests/axe-sitemap.spec.ts

--- a/scripts/retrieveSitemap
+++ b/scripts/retrieveSitemap
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-curl --insecure "$1/sitemap.xml" 2>/dev/null | xmllint --xpath '//*[local-name()="loc"]/text()' --format - > sitemap.links
+curl --insecure "$1" 2>/dev/null | xmllint --xpath '//*[local-name()="loc"]/text()' --format - > sitemap.links
 
 if [ ! -f sitemap.links ]; then
     echo "Could not retrieve sitemap.xml"

--- a/scripts/visreg-sitemap-test
+++ b/scripts/visreg-sitemap-test
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 
-./scripts/retrieveSitemap "$1"
+if [[ $1 != *.xml ]]; then
+    echo "$1" > ./links.sitemap
+else
+    ./scripts/retrieveSitemap "$1"
+fi
+
 playwright test ./tests/visreg-sitemap.spec.ts


### PR DESCRIPTION
The new way of calling a11y-sitemap-test and visreg-sitemap-test against a sitemap:

`npm run a11y https://sitewithsitemap.com/sitemap.xml`
`npm run visreg https://sitewithsitemap.com/sitemap.xml`

If the reference URL doesn't end in .xml, it will assume you are testing a page and attempt to only test that page.

Work for documentation on this will occur in #14 after this goes through.

### Testing
- [ ] Run `npm run a11y <url>` where <url> is the url of a specific website page
- [ ] Verify that it runs only that URL
- [ ] Run `npm run a11y <url>` where <url> is the url of a sitemap.xml file (like YaleSites)
- [ ] Verify that it runs all URLs inside of the sitemap
- [ ] Do the same for `npm run visreg <url>`
- [ ] Run `npm run sitemap <url>`
- [ ] Verify that in the case of a sitemap, sitemap.links has a list of links
- [ ] Verify that in the case of a single url to a page, sitemap.links has only that URL